### PR TITLE
Remove base checks for valid currency pairs

### DIFF
--- a/poloniex/api/base.py
+++ b/poloniex/api/base.py
@@ -61,8 +61,6 @@ class BasePublicApi:
 
     def get_params(self, command, **kwargs):
         currency_pair = kwargs.get("currency_pair")
-        if currency_pair and currency_pair not in constants.CURRENCY_PAIRS + ["all"]:
-            raise PoloniexError("Currency pair '{}' not available.".format(currency_pair))
 
         depth = kwargs.get("depth")
 
@@ -167,8 +165,6 @@ class BaseTradingApi:
 
     def get_params(self, command, **kwargs):
         currency_pair = kwargs.get("currency_pair")
-        if currency_pair and currency_pair not in constants.CURRENCY_PAIRS + ["all"]:
-            raise PoloniexError("Currency pair '{}' not available.".format(currency_pair))
 
         currency = kwargs.get("currency")
 


### PR DESCRIPTION
Reduce need to maintain the currency pair constant.
This will pay dividents as the crypo space explodes with forks.